### PR TITLE
dependencies: upgrade dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,22 +15,22 @@
   :uberjar-name "anon-files-standalone.jar"
   :main ^:skip-aot anon-files.core
   :profiles {:uberjar {:aot :all}}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.cyverse/clj-jargon "2.8.3"
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [org.cyverse/clj-jargon "3.0.0"
                   :exclusions [[org.slf4j/slf4j-log4j12]
                                [log4j]]]
-                 [org.cyverse/service-logging "2.8.0"]
+                 [org.cyverse/service-logging "2.8.3"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/clojure-commons "2.8.2"]
+                 [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/event-messages "0.0.1"]
                  [com.novemberain/langohr "3.5.1"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
-                 [medley "0.6.0"]
-                 [compojure "1.5.0"]
-                 [ring "1.5.0"]
+                 [medley "1.3.0"]
+                 [compojure "1.6.1"]
+                 [ring "1.6.0"]
                  [slingshot "0.10.3"]]
-  :plugins [[lein-ring "0.9.3"]
-            [jonase/eastwood "0.2.3"]
+  :plugins [[lein-ring "0.12.5"]
+            [jonase/eastwood "0.3.10"]
             [test2junit "1.2.2"]]
   :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/anon-files-logging.xml"]
   :eastwood {:exclude-namespaces [:test-paths]


### PR DESCRIPTION
building docker image or running server localy with `lein run` throws error:
```bash
Retrieving org/apache/apache/4/apache-4.pom from central
Tried to use insecure HTTP repository without TLS:
 renci-snapshot.repository: http://ci-dev.renci.org/nexus/content/repositories/renci-snapshot/
 com/claymoresystems/puretls/1.1/puretls-1.1.pom 
 
This is almost certainly a mistake; for details see 
https://github.com/technomancy/leiningen/blob/master/doc/FAQ.md
```